### PR TITLE
remove electron dependency for smaller size build

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
   "dependencies": {
     "copy-paste": "^1.3.0",
     "deckboard-kit": "^0.3.0",
-    "discord-rpc": "^4.0.1",
-    "electron": "^17.0.0"
+    "discord-rpc": "^4.0.1"
   },
   "devDependencies": {
     "deckboard-kit-cli": "^1.0.0"


### PR DESCRIPTION
**Description**

- Remove electron from dependency, so the final build size can be significantly reduced (200 MB to 8 MB)
- Pass and use the `dialog` module from the app itself to the extension instead from the electron dependency. This only works on Deckboard server app v2.0.0
- Fix the bug where the dialog won't show up when `discordAccessToken`'s value is `null` or `undefined`